### PR TITLE
Fix export crashes in Android 9

### DIFF
--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/SaveCalendar.java
@@ -231,11 +231,14 @@ public class SaveCalendar extends RunnableWithProgress {
         String where = Events.CALENDAR_ID + "=? AND deleted=0";
         String[] args = new String[] { cal_src.mIdStr };
         String sortBy = Events.CALENDAR_ID + " ASC";
-        Cursor cur;
+        Cursor cur = null;
+
         try {
             cur = resolver.query(Events.CONTENT_URI, mAllCols ? null : EVENT_COLS,
                                  where, args, sortBy);
-        } catch (Exception except) {
+        } catch (Exception ignored) {}
+
+        if(cur == null) {
             Log.w(TAG, "Calendar provider is missing columns, continuing anyway");
             int n = 0;
             for (n = 0; n < EVENT_COLS.length; ++n)

--- a/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ui/MainActivity.java
+++ b/CalendarImportExport/src/main/java/org/sufficientlysecure/ical/ui/MainActivity.java
@@ -355,6 +355,7 @@ public class MainActivity extends FragmentActivity implements View.OnClickListen
         boolean found = false;
         for (int i = 0; i < mCalendars.size(); i++) {
             if (mCalendars.get(i).mId == mIntentCalendarId &&
+                mCalendars.get(i).mName != null &&
                 (calendarName == null || mCalendars.get(i).mName.contentEquals(calendarName))) {
                 found = true;
                 final int index = i;


### PR DESCRIPTION
A null cursor is returned when providing missing columns